### PR TITLE
Change flex sdk version specifier to wildcard

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-mxmlc",
   "description": "A Grunt task plugin to compile Adobe Flex/ActionScript/MXML/FLV/etc. apps with the `mxmlc` compiler from the Apache/Adobe Flex SDK.",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "homepage": "https://github.com/JamesMGreene/grunt-mxmlc",
   "author": {
     "name": "James M. Greene",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "async": "^0.9.0"
   },
   "devDependencies": {
-    "flex-sdk": "^3.0.0-0 || ^4.0.0-0",
+    "flex-sdk": "*",
     "grunt": "^0.4.5",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-jshint": "^0.10.0",


### PR DESCRIPTION
This seems easiest to me. As someone not really in the node world I don't have much idea how to work around so less restrictive is better.
